### PR TITLE
Update clients page with campaign count and delete

### DIFF
--- a/public/client_delete.php
+++ b/public/client_delete.php
@@ -1,0 +1,26 @@
+<?php
+session_start();
+require __DIR__ . '/../config/db.php';
+require __DIR__ . '/includes/auth.php';
+require_permission($pdo, 'manage_clients');
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+if ($id) {
+    $stmt = $pdo->prepare("SELECT COUNT(*) FROM mktg_client_campaigns WHERE clientid = ?");
+    $stmt->execute([$id]);
+    if ($stmt->fetchColumn() == 0) {
+        $pdo->prepare("DELETE FROM mktg_client_links WHERE client_id = ?")->execute([$id]);
+        $pdo->prepare("DELETE FROM mktg_client_files WHERE client_id = ?")->execute([$id]);
+        $pdo->prepare("DELETE FROM mktg_clients WHERE id = ?")->execute([$id]);
+        $dir = __DIR__ . "/uploads/clients/$id";
+        if (is_dir($dir)) {
+            foreach (glob("$dir/*") as $f) {
+                if (is_file($f)) unlink($f);
+            }
+            @rmdir($dir);
+        }
+    }
+}
+
+header("Location: clients.php");
+exit;

--- a/public/client_form.php
+++ b/public/client_form.php
@@ -228,6 +228,11 @@ ob_start();
     <?php else: ?>
         <p class="text-muted">No links available.</p>
     <?php endif; ?>
+
+    <hr class="my-5">
+
+    <h4>📂 Assets</h4>
+    <p><a href="client_upload.php?client_id=<?= $id ?>" class="btn btn-outline-primary btn-sm">Manage Assets</a></p>
 <?php endif; ?>
 
 <?php $content = ob_get_clean(); ?>

--- a/public/clients.php
+++ b/public/clients.php
@@ -25,7 +25,7 @@ if ($country !== '') {
     $params[] = $country;
 }
 
-$sql = "SELECT * FROM mktg_clients";
+$sql = "SELECT c.*, (SELECT COUNT(*) FROM mktg_client_campaigns cc WHERE cc.clientid = c.id) AS campaign_count FROM mktg_clients c";
 if ($where) $sql .= " WHERE " . implode(" AND ", $where);
 $sql .= " ORDER BY client_name ASC";
 
@@ -82,6 +82,7 @@ ob_start();
             <th>Name</th>
             <th>Contact</th>
             <th>Country</th>
+            <th>Campaigns</th>
             <th>Actions</th>
         </tr>
     </thead>
@@ -96,14 +97,19 @@ ob_start();
                     <?= htmlspecialchars($client['contact_phone']) ?>
                 </td>
                 <td><?= htmlspecialchars($client['country']) ?></td>
+                <td><?= (int)$client['campaign_count'] ?></td>
                 <td>
                     <a href="client_form.php?id=<?= $client['id'] ?>" class="btn btn-sm btn-warning">Edit</a>
-                    <a href="client_upload.php?client_id=<?= $client['id'] ?>" class="btn btn-sm btn-primary">Assets</a>
+                    <?php if ($client['campaign_count'] > 0): ?>
+                        <button class="btn btn-sm btn-danger" disabled>Delete</button>
+                    <?php else: ?>
+                        <a href="client_delete.php?id=<?= $client['id'] ?>" class="btn btn-sm btn-danger" onclick="return confirm('Delete this client?')">Delete</a>
+                    <?php endif; ?>
                 </td>
             </tr>
         <?php endforeach; ?>
     <?php else: ?>
-        <tr><td colspan="4">No clients found.</td></tr>
+        <tr><td colspan="5">No clients found.</td></tr>
     <?php endif; ?>
     </tbody>
 </table>


### PR DESCRIPTION
## Summary
- show campaign count in clients list
- add ability to delete clients (disabled if campaigns exist)
- move asset management link to the client form

## Testing
- `php -l public/clients.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855731ccdbc832eaeca2c683d0ac3c2